### PR TITLE
Optimizacion de el atajo de teclado cmd+1

### DIFF
--- a/02-productivity_config_vscode/3-keyboard_optimization/keybindings.json
+++ b/02-productivity_config_vscode/3-keyboard_optimization/keybindings.json
@@ -1,11 +1,23 @@
 [
   {
     "key": "cmd+1",
-    "command": "workbench.action.focusSideBar"
+    "command": "runCommands",
+    "args": {
+      "commands": [    
+        "workbench.action.toggleSidebarVisibility",
+        "workbench.action.focusSideBar"
+      ]
+    }
   },
   {
     "key": "cmd+1",
-    "command": "workbench.action.toggleSidebarVisibility",
+    "command": "runCommands",
+    "args": {
+      "commands": [    
+        "workbench.action.focusSideBar",
+        "workbench.action.toggleSidebarVisibility"
+      ]
+    },
     "when": "sideBarFocus"
   },
   {


### PR DESCRIPTION
Con este optimización, pulsando una sola vez en el cmd+1 aparece el SideBar y se cambia el foco. A la inversa si lo volvemos a pulsar, se quita el foco y se cierra. **Lo importante, dos acciones con una pulsacion**